### PR TITLE
deps: pin heif-image-plugin to version 0.5.1

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -28,7 +28,7 @@ RUN pip3 install --no-cache-dir --disable-pip-version-check \
         "alembic>=0.8.5" \
         "coloredlogs==5.0" \
         "pyheif==0.6.1" \
-        "heif-image-plugin>=0.3.2" \
+        "heif-image-plugin==0.5.1" \
         yt-dlp \
         "pillow-avif-plugin~=1.1.0"
 RUN apk --no-cache del py3-pip

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,7 +1,7 @@
 alembic>=0.8.5
 certifi>=2017.11.5
 coloredlogs==5.0
-heif-image-plugin==0.3.2
+heif-image-plugin==0.5.1
 numpy>=1.8.2
 pillow-avif-plugin~=1.1.0
 pillow>=4.3.0


### PR DESCRIPTION
Not sure if this really matters, but it fixes a pip warning. https://github.com/uploadcare/heif-image-plugin/commit/cc55068d163d1139e142d021f6c820f88dfef63a